### PR TITLE
Add blank tenant-branding placeholders for app/dev/devaz

### DIFF
--- a/login/app.svg
+++ b/login/app.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 200" aria-hidden="true"/>

--- a/login/dev.svg
+++ b/login/dev.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 200" aria-hidden="true"/>

--- a/login/devaz.svg
+++ b/login/devaz.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 200" aria-hidden="true"/>

--- a/square-icons/app.svg
+++ b/square-icons/app.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" aria-hidden="true"/>

--- a/square-icons/dev.svg
+++ b/square-icons/dev.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" aria-hidden="true"/>

--- a/square-icons/devaz.svg
+++ b/square-icons/devaz.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" aria-hidden="true"/>


### PR DESCRIPTION
## Summary
- Adds transparent placeholder SVGs at `login/{app,dev,devaz}.svg` and `square-icons/{app,dev,devaz}.svg`.
- moderne-ui builds these convention URLs from the tenant name. The `TENANT_BRANDING_ENABLED` env var is being removed (moderneinc/moderne-ui#8114) so the lookup now happens unconditionally.
- These are intentionally blank — matches the pre-removal behavior where the env var was off and nothing tenant-branded rendered. Replace any of these files with a real logo to enable branding for that deployment.

## Test plan
- [ ] Each SVG opens in a browser as a transparent box (no broken-image icon, no visible content).
- [ ] After merge, the six raw URLs return HTTP 200.